### PR TITLE
[#20] feat: security 설정 및 로그인 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     // web
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/src/main/java/com/imhero/config/SecurityConfig.java
+++ b/src/main/java/com/imhero/config/SecurityConfig.java
@@ -1,0 +1,77 @@
+package com.imhero.config;
+
+import com.imhero.user.service.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomUserDetailsService userDetailsService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf().disable()
+                .authorizeRequests()
+                    .antMatchers("/api/v1/users", "/api/v1/users/login")
+                    .permitAll()
+                    .anyRequest().authenticated()
+                .and()
+                .exceptionHandling()
+                .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                .accessDeniedHandler(new CustomAccessDeniedHandler())
+                .and()
+                .formLogin().disable()
+                .httpBasic().disable()
+                .build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return new ProviderManager(Arrays.asList(provider));
+    }
+
+    private static class CustomAccessDeniedHandler implements AccessDeniedHandler {
+        @Override
+        public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Forbidden");
+        }
+    }
+
+    private static class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+        @Override
+        public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+        }
+    }
+}

--- a/src/main/java/com/imhero/config/exception/ErrorCode.java
+++ b/src/main/java/com/imhero/config/exception/ErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
     DUPLICATED_USER(HttpStatus.CONFLICT, "User is duplicated"),
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "Bad request"), ;
+    EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "email not found"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "Bad request"),
+    ;
 
     private HttpStatus status;
     private String message;

--- a/src/main/java/com/imhero/user/controller/UserController.java
+++ b/src/main/java/com/imhero/user/controller/UserController.java
@@ -1,0 +1,44 @@
+package com.imhero.user.controller;
+
+import com.imhero.config.exception.Response;
+import com.imhero.user.dto.UserDto;
+import com.imhero.user.dto.request.LoginRequest;
+import com.imhero.user.dto.request.UserRequest;
+import com.imhero.user.dto.response.LoginResponse;
+import com.imhero.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+    private final AuthenticationManager authenticationManager;
+
+    @PostMapping("/api/v1/users")
+    public Response<UserDto> join(@RequestBody UserRequest userRequest) {
+        return Response.success(userService.save(userRequest));
+    }
+
+    @PostMapping("/api/v1/users/login")
+    public Response<LoginResponse> login(@RequestBody LoginRequest loginRequest, HttpServletRequest request) {
+        Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword()));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        HttpSession session = request.getSession();
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, SecurityContextHolder.getContext());
+
+        return Response.success(userService.login(loginRequest));
+    }
+}

--- a/src/main/java/com/imhero/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/imhero/user/dto/request/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.imhero.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LoginRequest {
+
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/imhero/user/dto/response/LoginResponse.java
+++ b/src/main/java/com/imhero/user/dto/response/LoginResponse.java
@@ -1,0 +1,18 @@
+package com.imhero.user.dto.response;
+
+import com.imhero.user.domain.User;
+import lombok.Data;
+
+@Data
+public class LoginResponse {
+
+    private Long id;
+
+    private LoginResponse(Long id) {
+        this.id = id;
+    }
+
+    public static LoginResponse from(User user) {
+        return new LoginResponse(user.getId());
+    }
+}

--- a/src/main/java/com/imhero/user/service/CustomUserDetailsService.java
+++ b/src/main/java/com/imhero/user/service/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.imhero.user.service;
+
+import com.imhero.config.exception.ErrorCode;
+import com.imhero.config.exception.ImheroApplicationException;
+import com.imhero.user.domain.User;
+import com.imhero.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findUserByEmail(email)
+                .orElseThrow(() -> new ImheroApplicationException(ErrorCode.EMAIL_NOT_FOUND));
+        return new org.springframework.security.core.userdetails.User(user.getEmail(), user.getPassword(), new ArrayList<>());
+    }
+}

--- a/src/test/groovy/com/imhero/user/service/CustomUserDetailsServiceTest.groovy
+++ b/src/test/groovy/com/imhero/user/service/CustomUserDetailsServiceTest.groovy
@@ -1,0 +1,45 @@
+package com.imhero.user.service
+
+import com.imhero.config.exception.ErrorCode
+import com.imhero.config.exception.ImheroApplicationException
+import com.imhero.user.domain.User
+import com.imhero.user.repository.UserRepository
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import spock.lang.Shared
+import spock.lang.Specification
+
+class CustomUserDetailsServiceTest extends Specification {
+
+    @Shared String email = "email@gamil.com"
+    @Shared String password = "password1!!1"
+    @Shared String username = "username"
+
+    def "이메일로 회원 조회"() {
+        given:
+        UserRepository userRepository = Mock(UserRepository.class)
+        UserDetailsService userDetailsService = new CustomUserDetailsService(userRepository)
+        User user = User.of(email, password, username, "N")
+        userRepository.findUserByEmail(_) >> Optional.of(user)
+
+        when:
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email)
+
+        then:
+        userDetails.getUsername() == email
+    }
+
+    def "이메일로 회원 조회 실패"() {
+        given:
+        UserRepository userRepository = Mock(UserRepository.class)
+        UserDetailsService userDetailsService = new CustomUserDetailsService(userRepository)
+        userRepository.findUserByEmail(_) >> Optional.empty()
+
+        when:
+        userDetailsService.loadUserByUsername(email)
+
+        then:
+        def e = thrown(ImheroApplicationException)
+        e.errorCode == ErrorCode.EMAIL_NOT_FOUND
+    }
+}

--- a/src/test/groovy/com/imhero/user/service/UserServiceTest.groovy
+++ b/src/test/groovy/com/imhero/user/service/UserServiceTest.groovy
@@ -3,25 +3,24 @@ package com.imhero.user.service
 import com.imhero.user.domain.Role
 import com.imhero.user.domain.User
 import com.imhero.user.dto.UserDto
+import com.imhero.user.dto.request.LoginRequest
 import com.imhero.user.dto.request.UserRequest
+import com.imhero.user.dto.response.LoginResponse
 import com.imhero.user.repository.UserRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.transaction.annotation.Transactional
 import spock.lang.Shared
 import spock.lang.Specification
-
-import javax.persistence.EntityManager
 
 @Transactional
 @SpringBootTest
 class UserServiceTest extends Specification {
 
-    // spring security
-    // User details Service
-    // authentication check
-    // repository -> user, service -> dto, controller -> response 응답
+    @Autowired BCryptPasswordEncoder bCryptPasswordEncoder
+
     @Shared String email = "email@gamil.com"
     @Shared String password = "password1!!1"
     @Shared String passwordCheck = "password1!!1"
@@ -30,7 +29,7 @@ class UserServiceTest extends Specification {
     def "회원 가입"() {
         given:
         UserRepository userRepository = Mock(UserRepository.class)
-        UserService userService = new UserService(userRepository)
+        UserService userService = new UserService(userRepository, bCryptPasswordEncoder)
         User user = User.of(email, password, username, "N")
         UserRequest userRequest = new UserRequest(email, password,  username)
 
@@ -50,7 +49,7 @@ class UserServiceTest extends Specification {
     def "회원 가입시 이미 가입된 회원인 경우" () {
         given:
         UserRepository userRepository = Mock(UserRepository.class)
-        UserService userService = new UserService(userRepository)
+        UserService userService = new UserService(userRepository, bCryptPasswordEncoder)
         UserRequest userRequest = new UserRequest(email, password, username)
 
         when:
@@ -65,7 +64,7 @@ class UserServiceTest extends Specification {
     def "회원 조회"() {
         given:
         UserRepository userRepository = Mock(UserRepository.class)
-        UserService userService = new UserService(userRepository)
+        UserService userService = new UserService(userRepository, bCryptPasswordEncoder)
         User user = User.of(email, password, username, "N")
 
         when:
@@ -84,7 +83,7 @@ class UserServiceTest extends Specification {
     def "회원 조회시 회원이 없는 경우"() {
         given:
         UserRepository userRepository = Mock(UserRepository.class)
-        UserService userService = new UserService(userRepository)
+        UserService userService = new UserService(userRepository, bCryptPasswordEncoder)
 
         when:
         userService.findUserByEmail(email)
@@ -98,7 +97,7 @@ class UserServiceTest extends Specification {
     def "회원 수정"() {
         given:
         UserRepository userRepository = Mock(UserRepository.class)
-        UserService userService = new UserService(userRepository)
+        UserService userService = new UserService(userRepository, bCryptPasswordEncoder)
         User user = User.of(email, password, username, "N")
         UserRequest userRequest = new UserRequest(email, password, username)
 
@@ -117,7 +116,7 @@ class UserServiceTest extends Specification {
     def "회원 수정시 회원이 없는 경우" () {
         given:
         UserRepository userRepository = Mock(UserRepository.class)
-        UserService userService = new UserService(userRepository)
+        UserService userService = new UserService(userRepository, bCryptPasswordEncoder)
         UserRequest userRequest = new UserRequest(email, password, username)
 
         when:
@@ -132,7 +131,7 @@ class UserServiceTest extends Specification {
     def "회원 탈퇴"() {
         given:
         UserRepository userRepository = Mock(UserRepository.class)
-        UserService userService = new UserService(userRepository)
+        UserService userService = new UserService(userRepository, bCryptPasswordEncoder)
         User user = User.of(email, password, username, "N")
 
         when:
@@ -147,7 +146,7 @@ class UserServiceTest extends Specification {
     def "회원 탈퇴시 이미 탈퇴된 회원인 경우" () {
         given:
         UserRepository userRepository = Mock(UserRepository.class)
-        UserService userService = new UserService(userRepository)
+        UserService userService = new UserService(userRepository, bCryptPasswordEncoder)
         User user = User.of(email, password, username, "Y")
 
         when:
@@ -162,7 +161,7 @@ class UserServiceTest extends Specification {
     def "회원 탈퇴시 회원이 없는 경우"() {
         given:
         UserRepository userRepository = Mock(UserRepository.class)
-        UserService userService = new UserService(userRepository)
+        UserService userService = new UserService(userRepository, bCryptPasswordEncoder)
         User user = User.of(email, password, username, "N")
 
         when:
@@ -173,4 +172,20 @@ class UserServiceTest extends Specification {
         IllegalArgumentException e = thrown()
         e.getMessage() == "회원이 없습니다."
     }
+
+    def "로그인"() {
+        given:
+        UserRepository userRepository = Mock(UserRepository.class)
+        UserService userService = new UserService(userRepository, bCryptPasswordEncoder)
+        LoginRequest loginRequest = new LoginRequest(email, password)
+        User user = User.of(email, password, username, "N")
+        userRepository.findUserByEmail(_) >> Optional.of(user)
+
+        when:
+        LoginResponse loginResponse = userService.login(loginRequest)
+
+        then:
+        loginResponse.getId() == user.getId()
+    }
+
 }

--- a/src/test/http/user.http
+++ b/src/test/http/user.http
@@ -1,0 +1,18 @@
+### join
+POST http://localhost:8080/api/v1/users
+Content-Type: application/json
+
+{
+  "email": "test3@gmail.com",
+  "password": "test123456!",
+  "username": "test-name"
+}
+
+### login
+POST http://localhost:8080/api/v1/users/login
+Content-Type: application/json
+
+{
+  "email": "test3@gmail.com",
+  "password": "test123456!"
+}


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- #20 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
- security 설정 추가
   (BcryptPasswordEncoder 설정, CustomUserDetailsService 인증 추가, http filter 추가)

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- 로그인 시 Spring security에서 관리하는 AuthenticationManager에 DaoAuthenticationProvider를 추가하였습니다.
- DaoAuthenticationProvider의 필드에 customUserDetailsService, bcryptPasswordEncoder를 세팅하였습니다.
- 인증/인가 실패 시 에러 처리하는 handler를 재정의하였습니다.
- controller와 dto에 대한 테스트는 생략하였습니다.

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- https://docs.spring.io/spring-security/reference/servlet/authentication/architecture.html

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?