### PR TITLE
[#28] feat: authentication Principal 객체 세팅

### DIFF
--- a/src/main/java/com/imhero/user/service/CustomUserDetailsService.java
+++ b/src/main/java/com/imhero/user/service/CustomUserDetailsService.java
@@ -22,6 +22,20 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findUserByEmail(email)
                 .orElseThrow(() -> new ImheroApplicationException(ErrorCode.EMAIL_NOT_FOUND));
-        return new org.springframework.security.core.userdetails.User(user.getEmail(), user.getPassword(), new ArrayList<>());
+        return new CustomUserDetails(user);
+    }
+
+    public class CustomUserDetails extends org.springframework.security.core.userdetails.User {
+
+        private User user;
+
+        private CustomUserDetails(User user) {
+            super(user.getEmail(), user.getPassword(), new ArrayList<>());
+            this.user = user;
+        }
+
+        public User getUser() {
+            return user;
+        }
     }
 }

--- a/src/main/java/com/imhero/user/utils/UserUtils.java
+++ b/src/main/java/com/imhero/user/utils/UserUtils.java
@@ -1,0 +1,23 @@
+package com.imhero.user.utils;
+
+import com.imhero.config.exception.ErrorCode;
+import com.imhero.config.exception.ImheroApplicationException;
+import com.imhero.user.domain.User;
+import com.imhero.user.service.CustomUserDetailsService.CustomUserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Objects;
+
+public final class UserUtils {
+
+    public static User getAuthenticatedUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (Objects.isNull(authentication)) {
+            throw new ImheroApplicationException(ErrorCode.UNAUTHORIZED_BEHAVIOR);
+        }
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getUser();
+    }
+}

--- a/src/test/groovy/com/imhero/user/utils/UserUtilsTest.groovy
+++ b/src/test/groovy/com/imhero/user/utils/UserUtilsTest.groovy
@@ -1,0 +1,57 @@
+package com.imhero.user.utils
+
+import com.imhero.config.exception.ErrorCode
+import com.imhero.config.exception.ImheroApplicationException
+import com.imhero.fixture.Fixture
+import com.imhero.user.domain.User
+import com.imhero.user.dto.UserDto
+import com.imhero.user.dto.request.UserRequest
+import com.imhero.user.repository.UserRepository
+import com.imhero.user.service.UserService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.transaction.annotation.Transactional
+import spock.lang.Specification
+
+@SpringBootTest
+@Transactional
+class UserUtilsTest extends Specification {
+
+    @Autowired AuthenticationManager authenticationManager
+    @Autowired UserService userService
+    @Autowired UserRepository userRepository
+
+    def "로그인 유저 정보 조회"() {
+        given:
+        //회원가입
+        User user = Fixture.getUser()
+        UserDto userDto = userService.save(new UserRequest(user.getEmail(), user.getPassword(), user.getUsername()))
+
+        //로그인
+        Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(user.getEmail(), user.getPassword()));
+        SecurityContextHolder.getContext().setAuthentication(authentication)
+
+        when:
+        User findUser = userRepository.findById(userDto.getId()).get()
+        User authenticatedUser = UserUtils.getAuthenticatedUser()
+
+        then:
+        authenticatedUser == findUser
+    }
+
+    def "비로그인 유저 정보 조회 시 예외 처리"() {
+        given:
+        SecurityContextHolder.getContext().setAuthentication(null)
+
+        when:
+        UserUtils.getAuthenticatedUser()
+
+        then:
+        def e = thrown(ImheroApplicationException.class)
+        e.getErrorCode() == ErrorCode.UNAUTHORIZED_BEHAVIOR
+    }
+}


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- #28 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
- 현재는 SecurityContextHolder에서 SpringSecurity가 제공하는 UserDetails 객체에 email만 세팅하여 User 도메인에 대한 정보가 부족
- SecurityContextHolder의 Authentication Principal 객체를 기존 UserDetails가 아닌 CustomUserDetails로 변경
- 이를 통해 서비스 내에서 관리하는 User domain을 반환하도록 하여 SecurityContextHolder에서 현재 authenticated user 객체를 조회할 수 있도록 함

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
authenticated User 정보를 UserUtils에서 처리한 이유
- CustomUserDetails를 반환하게 만든 후에 SecurityContextHolder의 Principal 객체를 사용하는 방법은 Controller, Service layer에서 달라집니다.
  ```java
  //Controller
  @GetMapping("/user")
  public String test(@AuthenticationPrincipal CustomUserDetails userDetails) {
    User user = userDetails.getUser();
  }

  //Service1
  public void test(User user) {
    //...
  }
  
  //Service2
  public void test() {
    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
    if (authentication != null) {
      CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
    }
    User user = userDetails.getUser();
    // user 사용
  }
   ```
- Controller에서는 HTTP 객체에 접근할 수 있으므로 @AuthenticationPrincipal 어노테이션을 사용하여 Principal 객체를 직접 파라미터로 세팅하여 형변환하지 않아도 됩니다.
- Service에서는 HTTP 객체에 직접 접근할 수 없으므로 어노테이션을 통한 접근이 불가능합니다. 따라서 파라미터로 전달하거나 직접 SercurityContextHolder에 접근하여 형변환하여 객체를 가져와야 합니다.
- Service layer에서 파라미터로 전달받거나 context에 직접 접근 하는 방법은 추가적인 로직 처리가 필요하고, 로직에 대한 중복처리가 생길 수 있어 Util 클래스로 분리하였습니다.
- UserUtils 클래스의 getAuthenticatedUser() 메서드는 Security에 의존적일 수 있고, application exception을 던져서 유틸성 메서드에 적합하다고 볼 수는 없지만, 비즈니스 로직이 실행되는 서비스 레이어에서 주로 사용하기 위한 의도라 해당 클래스로 분리하였습니다.

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- N/A

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?