### PR TITLE
비관적 락을 사용한 동시성 제어

### DIFF
--- a/src/main/java/com/imhero/show/repository/SeatRepository.java
+++ b/src/main/java/com/imhero/show/repository/SeatRepository.java
@@ -2,6 +2,16 @@ package com.imhero.show.repository;
 
 import com.imhero.show.domain.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import javax.persistence.LockModeType;
+import java.util.Optional;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
+
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from Seat s where s.id = :id")
+    Optional<Seat> findBySeatWithPessimisticLock(@Param("id") Long id);
 }

--- a/src/main/java/com/imhero/show/service/SeatService.java
+++ b/src/main/java/com/imhero/show/service/SeatService.java
@@ -47,4 +47,10 @@ public class SeatService {
                 .findById(seatId)
                 .orElseThrow(() -> new ImheroApplicationException(ErrorCode.SEAT_NOT_FOUND));
     }
+
+    public Seat getSeatWithPessimisticLockOrElseThrow(Long seatId) {
+        return seatRepository
+                .findBySeatWithPessimisticLock(seatId)
+                .orElseThrow(() -> new ImheroApplicationException(ErrorCode.SEAT_NOT_FOUND));
+    }
 }

--- a/src/test/groovy/com/imhero/reservation/service/ReservationServiceTest.groovy
+++ b/src/test/groovy/com/imhero/reservation/service/ReservationServiceTest.groovy
@@ -28,6 +28,9 @@ import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 import java.time.LocalDateTime
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 @Transactional
 @SpringBootTest
@@ -52,7 +55,7 @@ class ReservationServiceTest extends Specification {
         ReservationService reservationService = new ReservationService(reservationRepository, userService, seatService)
 
         userService.getUserByEmailOrElseThrow(_) >> Fixture.getUser()
-        seatService.getSeatByIdOrElseThrow(_) >> Fixture.getSeat(Fixture.getShowDetail(Fixture.getShow(Fixture.getUser())))
+        seatService.getSeatWithPessimisticLockOrElseThrow(_) >> Fixture.getSeat(Fixture.getShowDetail(Fixture.getShow(Fixture.getUser())))
 
         ReservationRequest reservationRequest = getReservationRequest()
 
@@ -85,7 +88,7 @@ class ReservationServiceTest extends Specification {
 
         reservation.getDelYn()
         userService.getUserByEmailOrElseThrow(_) >> reservation.getUser()
-        seatService.getSeatByIdOrElseThrow(_) >> seat
+        seatService.getSeatWithPessimisticLockOrElseThrow(_) >> seat
         reservationRepository.findAllById(_) >> [reservation, Fixture.getReservation(Fixture.getUser(), Fixture.getSeat(Fixture.getShowDetail(Fixture.getShow(Fixture.getUser())))), Fixture.getReservation(Fixture.getUser(), Fixture.getSeat(Fixture.getShowDetail(Fixture.getShow(Fixture.getUser()))))]
         reservationRepository.updateDelYnByIds(_) >> count
 

--- a/src/test/groovy/com/imhero/show/repository/SeatRepositoryTest.groovy
+++ b/src/test/groovy/com/imhero/show/repository/SeatRepositoryTest.groovy
@@ -50,6 +50,18 @@ class SeatRepositoryTest extends Specification {
         savedSeat == findSeat
     }
 
+    def "좌석 단건 조회 - x lock"() {
+        given:
+        Seat seat = Seat.of(showDetail, Grade.A, 10)
+
+        when:
+        Seat savedSeat = seatRepository.save(seat)
+        Seat findSeat = seatRepository.findBySeatWithPessimisticLock(seat.getId()).get()
+
+        then:
+        savedSeat == findSeat
+    }
+
     def "좌석 전체 조회"() {
         given:
         Seat seat1 = Seat.of(showDetail, Grade.A, 10)

--- a/src/test/groovy/com/imhero/show/service/SeatServiceTest.groovy
+++ b/src/test/groovy/com/imhero/show/service/SeatServiceTest.groovy
@@ -44,6 +44,35 @@ class SeatServiceTest extends Specification {
         e.errorCode == ErrorCode.SEAT_NOT_FOUND
     }
 
+    def "좌석 단건 조회 - x lock"() {
+        given:
+        SeatRepository seatRepository = Mock(SeatRepository.class)
+        SeatService seatService = getSeatService(seatRepository, Mock(ShowDetailService.class))
+        Seat seat = getSeat()
+        seatRepository.findBySeatWithPessimisticLock(_) >> Optional.of(seat)
+
+        when:
+        Seat findSeat = seatService.getSeatWithPessimisticLockOrElseThrow(seat.getId())
+
+        then:
+        findSeat == seat
+    }
+
+    def "좌석 단건 조회 시 좌석 미존재 - x lock"() {
+        given:
+        SeatRepository seatRepository = Mock(SeatRepository.class)
+        SeatService seatService = getSeatService(seatRepository, Mock(ShowDetailService.class))
+        Seat seat = getSeat()
+        seatRepository.findBySeatWithPessimisticLock(_) >> Optional.empty()
+
+        when:
+        seatService.getSeatWithPessimisticLockOrElseThrow(seat.getId())
+
+        then:
+        def e = thrown(ImheroApplicationException)
+        e.errorCode == ErrorCode.SEAT_NOT_FOUND
+    }
+
     def "좌석 생성"() {
         given:
         SeatRepository seatRepository = Mock(SeatRepository.class)


### PR DESCRIPTION
## 📌Linked Issues
- #15 

## ✏Change Details
- x lock 을 사용하여 동시성 처리를 하였습니다.
- 예매 건수에 대한 처리가 목적이므로 seat 에 for update 로 select 해왔습니다.
- 맞춰서 test 코드들을 수정하였습니다.

## 💬Comment
- 테스트를 하며 성능이 좋지 않은 것을 확인하였고 이와 관련된 글을 작성할 예정입니다.
- 성능 개선을 위해서 첫 번째로는 reentrant lock 을 사용해보고
- 이후 분산락을 사용하는 방향으로 진행할 예정입니다. 

## 📑References
- 없음

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?