### PR TITLE
[#28] refactor: 인증 user 객체 세팅 로직 개선

### DIFF
--- a/src/main/java/com/imhero/config/SecurityConfig.java
+++ b/src/main/java/com/imhero/config/SecurityConfig.java
@@ -8,10 +8,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -21,7 +19,7 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -58,7 +56,7 @@ public class SecurityConfig {
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
         provider.setUserDetailsService(userDetailsService);
         provider.setPasswordEncoder(passwordEncoder());
-        return new ProviderManager(Arrays.asList(provider));
+        return new ProviderManager(List.of(provider));
     }
 
     private static class CustomAccessDeniedHandler implements AccessDeniedHandler {

--- a/src/main/java/com/imhero/reservation/controller/ReservationController.java
+++ b/src/main/java/com/imhero/reservation/controller/ReservationController.java
@@ -6,12 +6,10 @@ import com.imhero.reservation.dto.request.ReservationRequest;
 import com.imhero.reservation.dto.response.ReservationResponse;
 import com.imhero.reservation.dto.response.ReservationSellerResponse;
 import com.imhero.reservation.service.ReservationService;
+import com.imhero.user.components.AuthenticatedUser;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpSession;
 import java.util.List;
 import java.util.Set;
 
@@ -20,31 +18,26 @@ import java.util.Set;
 @RestController
 public class ReservationController {
     private final ReservationService reservationService;
+    private final AuthenticatedUser authenticatedUser;
 
     @GetMapping("/seller")
-    public Response<List<ReservationSellerResponse>> findAllSeatByEmail(HttpSession session) {
-        return Response.success(reservationService.findAllSeatByEmail(getUserName(session)));
+    public Response<List<ReservationSellerResponse>> findAllSeatByEmail() {
+        return Response.success(reservationService.findAllSeatByEmail(authenticatedUser.getUser().getEmail()));
     }
 
     @GetMapping("")
-    public Response<ReservationResponse> findAllReservationByEmail(HttpSession session) {
-        return Response.success(reservationService.findAllReservationByEmail(getUserName(session)));
+    public Response<ReservationResponse> findAllReservationByEmail() {
+        return Response.success(reservationService.findAllReservationByEmail(authenticatedUser.getUser().getEmail()));
     }
 
     @PostMapping("")
-    public Response<Set<Long>> save(@RequestBody ReservationRequest reservationRequest, HttpSession session) {
-        return Response.success(reservationService.save(getUserName(session), reservationRequest));
+    public Response<Set<Long>> save(@RequestBody ReservationRequest reservationRequest) {
+        return Response.success(reservationService.save(reservationRequest));
     }
 
     @DeleteMapping("")
-    public Response<Void> cancel(@RequestBody ReservationCancelRequest reservationCancelRequest, HttpSession session) {
-
-        reservationService.cancel(getUserName(session), reservationCancelRequest);
+    public Response<Void> cancel(@RequestBody ReservationCancelRequest reservationCancelRequest) {
+        reservationService.cancel(reservationCancelRequest);
         return Response.success();
-    }
-
-    private String getUserName(HttpSession session) {
-        SecurityContext context = (SecurityContext) session.getAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY);
-        return context.getAuthentication().getName();
     }
 }

--- a/src/main/java/com/imhero/reservation/service/ReservationService.java
+++ b/src/main/java/com/imhero/reservation/service/ReservationService.java
@@ -10,6 +10,7 @@ import com.imhero.reservation.dto.response.ReservationSellerResponse;
 import com.imhero.reservation.repository.ReservationRepository;
 import com.imhero.show.domain.Seat;
 import com.imhero.show.service.SeatService;
+import com.imhero.user.components.AuthenticatedUser;
 import com.imhero.user.domain.User;
 import com.imhero.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final UserService userService;
     private final SeatService seatService;
+    private final AuthenticatedUser authenticatedUser;
 
     @Transactional(readOnly = true)
     public List<ReservationSellerResponse> findAllSeatByEmail(String email) {
@@ -44,8 +46,8 @@ public class ReservationService {
     }
 
     @Transactional
-    public Set<Long> save(String userName, ReservationRequest reservationRequest) {
-        User user = getUser(userName);
+    public Set<Long> save(ReservationRequest reservationRequest) {
+        User user = getUser(authenticatedUser.getUser().getId());
         Seat seat = seatService.getSeatWithPessimisticLockOrElseThrow(reservationRequest.getSeatId());
 
         List<Reservation> reservations = reservationRepository.saveAll(
@@ -62,8 +64,8 @@ public class ReservationService {
     }
 
     @Transactional
-    public void cancel(String userName, ReservationCancelRequest reservationCancelRequest) {
-        User user = getUser(userName);
+    public void cancel(ReservationCancelRequest reservationCancelRequest) {
+        User user = getUser(authenticatedUser.getUser().getId());
         Seat seat = seatService.getSeatWithPessimisticLockOrElseThrow(reservationCancelRequest.getSeatId());
 
         List<Reservation> reservations = reservationRepository.findAllById(reservationCancelRequest.getIds());
@@ -79,7 +81,7 @@ public class ReservationService {
         seat.cancel(deleteCount);
     }
 
-    private User getUser(String userName) {
-        return userService.getUserByEmailOrElseThrow(userName);
+    private User getUser(Long userId) {
+        return userService.getUserByIdOrElseThrow(userId);
     }
 }

--- a/src/main/java/com/imhero/user/components/AuthenticatedUser.java
+++ b/src/main/java/com/imhero/user/components/AuthenticatedUser.java
@@ -1,4 +1,4 @@
-package com.imhero.user.utils;
+package com.imhero.user.components;
 
 import com.imhero.config.exception.ErrorCode;
 import com.imhero.config.exception.ImheroApplicationException;
@@ -6,12 +6,14 @@ import com.imhero.user.domain.User;
 import com.imhero.user.service.CustomUserDetailsService.CustomUserDetails;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 
 import java.util.Objects;
 
-public final class UserUtils {
+@Component
+public class AuthenticatedUser {
 
-    public static User getAuthenticatedUser() {
+    public User getUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (Objects.isNull(authentication)) {
             throw new ImheroApplicationException(ErrorCode.UNAUTHORIZED_BEHAVIOR);

--- a/src/test/groovy/com/imhero/user/components/AuthenticatedUserTest.groovy
+++ b/src/test/groovy/com/imhero/user/components/AuthenticatedUserTest.groovy
@@ -1,4 +1,4 @@
-package com.imhero.user.utils
+package com.imhero.user.components
 
 import com.imhero.config.exception.ErrorCode
 import com.imhero.config.exception.ImheroApplicationException
@@ -19,7 +19,7 @@ import spock.lang.Specification
 
 @SpringBootTest
 @Transactional
-class UserUtilsTest extends Specification {
+class AuthenticatedUserTest extends Specification {
 
     @Autowired AuthenticationManager authenticationManager
     @Autowired UserService userService
@@ -35,9 +35,11 @@ class UserUtilsTest extends Specification {
         Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(user.getEmail(), user.getPassword()));
         SecurityContextHolder.getContext().setAuthentication(authentication)
 
+        AuthenticatedUser authUser = new AuthenticatedUser()
+
         when:
         User findUser = userRepository.findById(userDto.getId()).get()
-        User authenticatedUser = UserUtils.getAuthenticatedUser()
+        User authenticatedUser = authUser.getUser()
 
         then:
         authenticatedUser == findUser
@@ -46,9 +48,10 @@ class UserUtilsTest extends Specification {
     def "비로그인 유저 정보 조회 시 예외 처리"() {
         given:
         SecurityContextHolder.getContext().setAuthentication(null)
+        AuthenticatedUser authUser = new AuthenticatedUser()
 
         when:
-        UserUtils.getAuthenticatedUser()
+        authUser.getUser()
 
         then:
         def e = thrown(ImheroApplicationException.class)


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- #28 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
- utils로 처리하던 로그인 유저 정보를 담고 있는 principal 객체를 AuthenticatedUser bean으로 등록하여 활용
- controller layer 로그인 유저 정보 의존성 제거
- service layer 내에서 session 정보를 통해 로그인 유저 정보를 받던 로직을 AuthenticatedUser bean을 주입 받는 로직으로 수정

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- N/A

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- N/A

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?