### PR TITLE
공연 검색 기능 추가

### DIFF
--- a/src/main/java/com/imhero/show/controller/ShowController.java
+++ b/src/main/java/com/imhero/show/controller/ShowController.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/show")
@@ -24,8 +26,13 @@ public class ShowController {
     }
 
     @GetMapping("/search")
-    public Response<Page<ShowResponse>> findAllByFullTextSearch(Pageable pageable, @RequestParam("keyword") String keyword) {
-        return Response.success(showService.findAllByFullTextSearch(pageable, keyword));
+    public Response<Page<ShowResponse>> findAllByFullTextSearch(
+            Pageable pageable,
+            @RequestParam("keyword") String keyword,
+            @RequestParam("fromDate") String fromDate,
+            @RequestParam("toDate") String toDate
+    ) {
+        return Response.success(showService.findAllByFullTextSearch(pageable, keyword, fromDate, toDate));
     }
 
     @GetMapping("/{showId}")

--- a/src/main/java/com/imhero/show/controller/ShowController.java
+++ b/src/main/java/com/imhero/show/controller/ShowController.java
@@ -23,6 +23,11 @@ public class ShowController {
         return Response.success(showService.findAll(pageable, delYn));
     }
 
+    @GetMapping("/search")
+    public Response<Page<ShowResponse>> findAllByFullTextSearch(Pageable pageable, @RequestParam("keyword") String keyword) {
+        return Response.success(showService.findAllByFullTextSearch(pageable, keyword));
+    }
+
     @GetMapping("/{showId}")
     public Response<ShowResponse> findById(@PathVariable Long showId, @RequestParam("del_yn") String delYn) {
         return Response.success(showService.findById(showId, delYn));

--- a/src/main/java/com/imhero/show/repository/ShowRepository.java
+++ b/src/main/java/com/imhero/show/repository/ShowRepository.java
@@ -17,7 +17,9 @@ public interface ShowRepository extends JpaRepository<Show, Long> {
             " FROM shows" +
             " WHERE MATCH(title, artist, place)" +
             " AGAINST(?1 IN NATURAL LANGUAGE MODE)" +
+            " AND show_from_date BETWEEN ?2 and ?3" +
+            " OR show_to_date BETWEEN ?2 and ?3" +
             " ORDER BY ID DESC",
             nativeQuery = true)
-    Page<Show> findAllByFullTextSearch(Pageable pageable, String keyword);
+    Page<Show> findAllByFullTextSearch(Pageable pageable, String keyword, String fromDate, String toDate);
 }

--- a/src/main/java/com/imhero/show/repository/ShowRepository.java
+++ b/src/main/java/com/imhero/show/repository/ShowRepository.java
@@ -4,10 +4,20 @@ import com.imhero.show.domain.Show;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface ShowRepository extends JpaRepository<Show, Long> {
     Optional<Show> findShowByIdAndDelYn(Long id, String delYn);
+
     Page<Show> findAllByDelYn(Pageable pageable, String delYn);
+
+    @Query(value = "SELECT *" +
+            " FROM shows" +
+            " WHERE MATCH(title, artist, place)" +
+            " AGAINST(?1 IN NATURAL LANGUAGE MODE)" +
+            " ORDER BY ID DESC",
+            nativeQuery = true)
+    Page<Show> findAllByFullTextSearch(Pageable pageable, String keyword);
 }

--- a/src/main/java/com/imhero/show/service/ShowService.java
+++ b/src/main/java/com/imhero/show/service/ShowService.java
@@ -28,6 +28,11 @@ public class ShowService {
     }
 
     @Transactional(readOnly = true)
+    public Page<ShowResponse> findAllByFullTextSearch(Pageable pageable, String keyword) {
+        return showRepository.findAllByFullTextSearch(pageable, keyword).map(ShowResponse::from);
+    }
+
+    @Transactional(readOnly = true)
     public ShowResponse findById(Long showId, String delYn) {
         return ShowResponse.from(getShowByIdAndDelYn(showId, delYn));
     }

--- a/src/main/java/com/imhero/show/service/ShowService.java
+++ b/src/main/java/com/imhero/show/service/ShowService.java
@@ -14,11 +14,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
 @Slf4j
 @RequiredArgsConstructor
 @Transactional
 @Service
 public class ShowService {
+    private static final String DEFAULT_FROM_DATE = "1990-01-01";
     private final ShowRepository showRepository;
     private final UserService userService;
 
@@ -28,8 +31,17 @@ public class ShowService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ShowResponse> findAllByFullTextSearch(Pageable pageable, String keyword) {
-        return showRepository.findAllByFullTextSearch(pageable, keyword).map(ShowResponse::from);
+    public Page<ShowResponse> findAllByFullTextSearch(Pageable pageable, String keyword, String fromDate, String toDate) {
+        if (fromDate.isEmpty()) {
+            fromDate = DEFAULT_FROM_DATE;
+        }
+        if (toDate.isEmpty()) {
+            toDate = LocalDate.now().plusYears(10).toString();
+        }
+        fromDate = fromDate + " 00:00:00";
+        toDate = toDate + " 23:59:59";
+
+        return showRepository.findAllByFullTextSearch(pageable, keyword, fromDate, toDate).map(ShowResponse::from);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,9 @@
 logging:
   level:
     root: info
+    org.hibernate:
+      type:
+        descriptor.sql: trace
   pattern:
     console: "%clr(%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}){faint} %clr(%5p) %clr(${PID: }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%X{uuid}){yellow} %clr(%X{userId}){yellow} %clr(%-40.40logger){cyan} %clr(:){faint} %msg%n"
 spring:

--- a/src/main/resources/sql/ddl.sql
+++ b/src/main/resources/sql/ddl.sql
@@ -34,7 +34,8 @@ create table shows (
 	modified_at datetime(6),
 	modified_by varchar(50),
 	primary key (id),
-	index (user_id)
+	index (user_id),
+    fulltext (title, artist, place)
 )
 ;
 

--- a/src/main/resources/sql/ddl.sql
+++ b/src/main/resources/sql/ddl.sql
@@ -35,7 +35,7 @@ create table shows (
 	modified_by varchar(50),
 	primary key (id),
 	index (user_id),
-    fulltext (title, artist, place)
+    fulltext (title, artist, place) with parser ngram
 )
 ;
 

--- a/src/test/groovy/com/imhero/show/service/ShowServiceTest.groovy
+++ b/src/test/groovy/com/imhero/show/service/ShowServiceTest.groovy
@@ -38,6 +38,24 @@ class ShowServiceTest extends Specification {
         findShowList.getContent().get(0).title == show.getTitle()
     }
 
+    def "공연 조회 - fulltext"() {
+        given:
+        ShowRepository showRepository = Mock(ShowRepository.class)
+        ShowService showService = getShowService(showRepository, Mock(UserService.class))
+        Show show = getShow()
+        List<Show> showList = Arrays.asList(show, show, show, show, show, show);
+        Page<Show> showPage = new PageImpl<>(showList, PageRequest.of(0, 1), showList.size());
+        showRepository.findAllByFullTextSearch(_, _) >> showPage
+
+        when:
+        Page<ShowResponse> findShowList = showService.findAllByFullTextSearch(PageRequest.of(0, 1), "test")
+
+        then:
+        findShowList.size() == 6
+        findShowList.totalPages == 6
+        findShowList.getContent().get(0).title == show.getTitle()
+    }
+
     def "공연 조회 개별"() {
         given:
         ShowRepository showRepository = Mock(ShowRepository.class)

--- a/src/test/groovy/com/imhero/show/service/ShowServiceTest.groovy
+++ b/src/test/groovy/com/imhero/show/service/ShowServiceTest.groovy
@@ -45,10 +45,10 @@ class ShowServiceTest extends Specification {
         Show show = getShow()
         List<Show> showList = Arrays.asList(show, show, show, show, show, show);
         Page<Show> showPage = new PageImpl<>(showList, PageRequest.of(0, 1), showList.size());
-        showRepository.findAllByFullTextSearch(_, _) >> showPage
+        showRepository.findAllByFullTextSearch(_, _, _, _) >> showPage
 
         when:
-        Page<ShowResponse> findShowList = showService.findAllByFullTextSearch(PageRequest.of(0, 1), "test")
+        Page<ShowResponse> findShowList = showService.findAllByFullTextSearch(PageRequest.of(0, 1), "test", "", "")
 
         then:
         findShowList.size() == 6

--- a/src/test/http/show.http
+++ b/src/test/http/show.http
@@ -18,3 +18,7 @@ Content-Type: application/json
 ### find
 GET http://localhost:8080/api/v1/show/1?del_yn=N
 Content-Type: application/json
+
+### findAllByFullTextSearch
+GET http://localhost:8080/api/v1/show/search?keyword=mo&page=0&size=1&del_yn=N
+Content-Type: application/json

--- a/src/test/http/show.http
+++ b/src/test/http/show.http
@@ -20,5 +20,5 @@ GET http://localhost:8080/api/v1/show/1?del_yn=N
 Content-Type: application/json
 
 ### findAllByFullTextSearch
-GET http://localhost:8080/api/v1/show/search?keyword=mo&page=0&size=1&del_yn=N
+GET http://localhost:8080/api/v1/show/search?keyword=mo&page=0&size=10&fromDate=&toDate=
 Content-Type: application/json


### PR DESCRIPTION
## 📌Linked Issues
- #7 

## ✏Change Details
- 공연 검색 기능을 개발하였습니다.
- ngram parser + natural language mode 를 사용하였습니다.
- 형태소 분석을 사용하기 어려운 상황이라 ngram parser 를 사용하였습니다.
- 부정확한 토큰이 들어오더라도 검색할 수 있게 하면서 최대한의 성능을 위해 natural language mode 를 사용하였습니다.

## 💬Comment
- 검색기능에 해당하는 repository 의 테스트를 진행하지 못했습니다. 이유는 다음과 같습니다.
1. h2 는 자체적인 fulltext index 설정 방법과 fulltext search 기능을 갖고 있습니다.
1-1. h2 fulltext index 설정은 test package 에 schema 로 설정할 수 있지만, search 기능은 따로 쿼리를 작성해야 합니다.
1-2. 쿼리를 따로 작성해서 테스트한다면, 서비스에 나가는 쿼리랑 다르기 때문에 테스트의 의미가 퇴색된다고 생각했습니다.
2. 위의 두 자체적인 기능은 아직 JPA 에서 지원하지 않습니다.
3. 따라서 MySQL 에 물려서 사용해야 하는데 fulltext index 는 데이터가 commit 되기 이전에는 생성되지 않습니다.
4. test 내부에서 강제로 flush 하여 진행할 수 있지만 그럼 데이터를 다시 지워야 하고 A.I 가 흐트러집니다.

## 📑References
- <a href="https://github.com/h2database/h2database/blob/master/h2/src/test/org/h2/samples/fullTextSearch.sql">H2 fulltext index-search 사용법</a>

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?