### PR TITLE
MySQL Replication 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     // spock
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation 'org.spockframework:spock-spring:2.3-groovy-4.0'
+
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 tasks.named('test') {

--- a/mysql/docker-compose.yml
+++ b/mysql/docker-compose.yml
@@ -1,0 +1,52 @@
+version: "3"
+services:
+  db-master:
+    container_name: mysql-master
+    build:
+      context: ./master/
+      dockerfile: Dockerfile
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 12345678
+      MYSQL_USER_PASSWORD: 12345678
+      MYSQL_DATABASE: imhero
+    ports:
+      - "3306:3306"
+    volumes:
+      - master_vol:/var/lib/mysql
+      - ./master/scripts:/docker-entrypoint-initdb.d
+    networks:
+      net-mysql:
+        ipv4_address: 172.28.0.2
+
+  db-slave:
+    container_name: mysql-slave
+    build:
+      context: ./slave
+      dockerfile: Dockerfile
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 12345678
+      MYSQL_USER_PASSWORD: 12345678
+      MYSQL_DATABASE: imhero
+    ports:
+      - "3307:3306"
+    volumes:
+      - slave_vol:/var/lib/mysql
+      - ./slave/scripts:/docker-entrypoint-initdb.d
+    networks:
+      net-mysql:
+        ipv4_address: 172.28.0.3
+    depends_on:
+      - db-master
+
+volumes:
+  master_vol:
+  slave_vol:
+
+networks:
+  net-mysql:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16

--- a/mysql/master/Dockerfile
+++ b/mysql/master/Dockerfile
@@ -1,0 +1,7 @@
+FROM mysql:8.0.32
+
+USER root
+ADD ./master.cnf /etc/mysql/my.cnf
+RUN mkdir /var/log/mysql
+RUN touch /var/log/mysql/error.log
+RUN chmod -R 777 /var/log/mysql/

--- a/mysql/master/master.cnf
+++ b/mysql/master/master.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+log-bin=mysql-bin
+server-id=1
+lower_case_table_names=1
+log_error=/var/log/mysql/error.log
+expire_logs_days=10
+max_binlog_size=100M

--- a/mysql/master/scripts/ddl.sql
+++ b/mysql/master/scripts/ddl.sql
@@ -1,0 +1,86 @@
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS shows;
+DROP TABLE IF EXISTS show_detail;
+DROP TABLE IF EXISTS seat;
+DROP TABLE IF EXISTS reservation;
+
+create table users (
+	id bigint not null auto_increment,
+	del_yn varchar(1),
+	email varchar(50),
+	password varchar(255),
+	role varchar(20),
+	username varchar(50),
+	created_at datetime(6),
+	created_by varchar(50),
+	modified_at datetime(6),
+	modified_by varchar(50),
+	primary key (id),
+	unique key (email)
+)
+;
+
+create table shows (
+	id bigint not null auto_increment,
+	artist varchar(50),
+	del_yn varchar(1),
+	place varchar(255),
+	show_from_date datetime(6),
+	show_to_date datetime(6),
+	title varchar(255),
+	user_id bigint,
+	created_at datetime(6),
+	created_by varchar(50),
+	modified_at datetime(6),
+	modified_by varchar(50),
+	primary key (id),
+	index (user_id),
+    fulltext (title, artist, place) with parser ngram
+)
+;
+
+create table show_detail (
+	id bigint not null auto_increment,
+	del_yn varchar(1),
+	reservation_from_dt datetime(6),
+	reservation_to_dt datetime(6),
+	sequence integer,
+	show_from_dt datetime(6),
+	show_to_dt datetime(6),
+	show_id bigint,
+	created_at datetime(6),
+	created_by varchar(50),
+	modified_at datetime(6),
+	modified_by varchar(50),
+	primary key (id),
+	index (show_id)
+)
+;
+
+create table seat (
+	id bigint not null auto_increment,
+	current_quantity integer not null,
+	grade varchar(10),
+	price integer,
+	total_quantity integer not null,
+	show_detail_id bigint,
+	created_at datetime(6),
+	created_by varchar(50),
+	modified_at datetime(6),
+	modified_by varchar(50),
+	primary key (id),
+	index (show_detail_id)
+)
+;
+
+create table reservation (
+    id bigint not null auto_increment,
+	del_yn varchar(1),
+	user_id bigint,
+	seat_id bigint,
+    created_at datetime(6),
+    modified_at datetime(6),
+	primary key (id),
+	index (user_id)
+)
+;

--- a/mysql/master/scripts/docker-entrypoint-master.sh
+++ b/mysql/master/scripts/docker-entrypoint-master.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+until mysqladmin -u root -p"${MYSQL_ROOT_PASSWORD}" ping; do
+  echo "# waiting for mysql - $(date)"
+  sleep 3
+done
+
+# 유저 생성
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "CREATE USER 'imhero'@'172.28.0.%' IDENTIFIED BY '${MYSQL_USER_PASSWORD}'"
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "GRANT ALL PRIVILEGES ON *.* TO 'imhero'@'172.28.0.%' WITH GRANT OPTION"
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "GRANT REPLICATION SLAVE ON *.* TO 'imhero'@'172.28.0.%'"
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "FLUSH PRIVILEGES"
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "STOP SLAVE"

--- a/mysql/slave/Dockerfile
+++ b/mysql/slave/Dockerfile
@@ -1,0 +1,7 @@
+FROM mysql:8.0.32
+
+USER root
+ADD ./slave.cnf /etc/mysql/my.cnf
+RUN mkdir /var/log/mysql
+RUN touch /var/log/mysql/error.log
+RUN chmod -R 777 /var/log/mysql/

--- a/mysql/slave/scripts/ddl.sql
+++ b/mysql/slave/scripts/ddl.sql
@@ -1,0 +1,86 @@
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS shows;
+DROP TABLE IF EXISTS show_detail;
+DROP TABLE IF EXISTS seat;
+DROP TABLE IF EXISTS reservation;
+
+create table users (
+	id bigint not null auto_increment,
+	del_yn varchar(1),
+	email varchar(50),
+	password varchar(255),
+	role varchar(20),
+	username varchar(50),
+	created_at datetime(6),
+	created_by varchar(50),
+	modified_at datetime(6),
+	modified_by varchar(50),
+	primary key (id),
+	unique key (email)
+)
+;
+
+create table shows (
+	id bigint not null auto_increment,
+	artist varchar(50),
+	del_yn varchar(1),
+	place varchar(255),
+	show_from_date datetime(6),
+	show_to_date datetime(6),
+	title varchar(255),
+	user_id bigint,
+	created_at datetime(6),
+	created_by varchar(50),
+	modified_at datetime(6),
+	modified_by varchar(50),
+	primary key (id),
+	index (user_id),
+    fulltext (title, artist, place) with parser ngram
+)
+;
+
+create table show_detail (
+	id bigint not null auto_increment,
+	del_yn varchar(1),
+	reservation_from_dt datetime(6),
+	reservation_to_dt datetime(6),
+	sequence integer,
+	show_from_dt datetime(6),
+	show_to_dt datetime(6),
+	show_id bigint,
+	created_at datetime(6),
+	created_by varchar(50),
+	modified_at datetime(6),
+	modified_by varchar(50),
+	primary key (id),
+	index (show_id)
+)
+;
+
+create table seat (
+	id bigint not null auto_increment,
+	current_quantity integer not null,
+	grade varchar(10),
+	price integer,
+	total_quantity integer not null,
+	show_detail_id bigint,
+	created_at datetime(6),
+	created_by varchar(50),
+	modified_at datetime(6),
+	modified_by varchar(50),
+	primary key (id),
+	index (show_detail_id)
+)
+;
+
+create table reservation (
+    id bigint not null auto_increment,
+	del_yn varchar(1),
+	user_id bigint,
+	seat_id bigint,
+    created_at datetime(6),
+    modified_at datetime(6),
+	primary key (id),
+	index (user_id)
+)
+;

--- a/mysql/slave/scripts/docker-entrypoint-slave.sh
+++ b/mysql/slave/scripts/docker-entrypoint-slave.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+until mysqladmin -u root -p"${MYSQL_ROOT_PASSWORD}" -h 172.28.0.2 ping; do
+  echo "# waiting for master - $(date)"
+  sleep 3
+done
+
+# 유저 생성
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "CREATE USER 'imhero'@'172.28.0.%' IDENTIFIED BY '${MYSQL_USER_PASSWORD}'"
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "GRANT ALL PRIVILEGES ON *.* TO 'imhero'@'172.28.0.%' WITH GRANT OPTION"
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "FLUSH PRIVILEGES"
+
+# master log file 가져옴
+master_log_file=$(mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -h 172.28.0.2 -e "SHOW MASTER STATUS\G" | grep mysql-bin)
+re="[a-z]*-bin.[0-9]*"
+
+if [[ $master_log_file =~ $re ]];then
+  master_log_file=${BASH_REMATCH[0]}
+fi
+
+# 마스터 log position 가져옴
+master_log_pos=$(mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -h 172.28.0.2 -e "SHOW MASTER STATUS\G" | grep Position)
+re="[0-9]+"
+
+if [[ $master_log_pos =~ $re ]];then
+  master_log_pos=${BASH_REMATCH[0]}
+fi
+
+# 마스터 연결
+sql="CHANGE MASTER TO MASTER_HOST='172.28.0.2', MASTER_USER='imhero', MASTER_PASSWORD='${MYSQL_USER_PASSWORD}', MASTER_LOG_FILE='${master_log_file}', MASTER_LOG_POS=${master_log_pos}, GET_MASTER_PUBLIC_KEY=1"
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "${sql}"
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "START SLAVE"

--- a/mysql/slave/slave.cnf
+++ b/mysql/slave/slave.cnf
@@ -1,0 +1,9 @@
+[mysqld]
+log-bin=mysql-bin
+server-id=2
+relay_log=/var/lib/mysql/mysql-relay-bin
+read_only=1
+lower_case_table_names=1
+log_error=/var/log/mysql/error.log
+expire_logs_days=10
+max_binlog_size=100M

--- a/src/main/java/com/imhero/config/datasource/DataSourceType.java
+++ b/src/main/java/com/imhero/config/datasource/DataSourceType.java
@@ -1,0 +1,16 @@
+package com.imhero.config.datasource;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.context.annotation.Profile;
+
+@Profile("local")
+@Getter
+@AllArgsConstructor
+public enum DataSourceType {
+    SLAVE("slave"),
+    MASTER("master"),
+    ;
+
+    private final String name;
+}

--- a/src/main/java/com/imhero/config/datasource/ReplicationDataSourceProperties.java
+++ b/src/main/java/com/imhero/config/datasource/ReplicationDataSourceProperties.java
@@ -1,0 +1,33 @@
+package com.imhero.config.datasource;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Profile("local")
+@Setter
+@Getter
+@Component
+@ConfigurationProperties(prefix = "spring.datasource")
+public class ReplicationDataSourceProperties {
+    private String driverClassName;
+    private String username;
+    private String password;
+    private String url;
+    private final Map<String, Slave> slaves = new HashMap<>();
+
+    @Getter
+    @Setter
+    public static class Slave {
+        private String name;
+        private String driverClassName;
+        private String username;
+        private String password;
+        private String url;
+    }
+}

--- a/src/main/java/com/imhero/config/datasource/ReplicationDatasourceConfig.java
+++ b/src/main/java/com/imhero/config/datasource/ReplicationDatasourceConfig.java
@@ -1,0 +1,92 @@
+package com.imhero.config.datasource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Profile("local")
+@Configuration
+@RequiredArgsConstructor
+public class ReplicationDatasourceConfig {
+    private final JpaProperties jpaProperties;
+    private final ReplicationDataSourceProperties dataSourceProperties;
+
+    @Bean
+    public DataSource routingDataSource() {
+        Map<Object, Object> targetDataSources = new LinkedHashMap<>();
+
+        DataSource masterDataSource = createDataSource(
+                dataSourceProperties.getDriverClassName(),
+                dataSourceProperties.getUsername(),
+                dataSourceProperties.getPassword(),
+                dataSourceProperties.getUrl()
+        );
+        targetDataSources.put(DataSourceType.MASTER.getName(), masterDataSource);
+
+        for (ReplicationDataSourceProperties.Slave slave : dataSourceProperties.getSlaves().values()) {
+            DataSource slaveDataSource = createDataSource(
+                    slave.getDriverClassName(),
+                    slave.getUsername(),
+                    slave.getPassword(),
+                    slave.getUrl()
+            );
+            targetDataSources.put(slave.getName(), slaveDataSource);
+        }
+
+        ReplicationRoutingSource routingDataSource = new ReplicationRoutingSource();
+        routingDataSource.setTargetDataSources(targetDataSources);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+
+        return routingDataSource;
+    }
+
+    private DataSource createDataSource(String driverClassName, String userName, String password, String uri) {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .driverClassName(driverClassName)
+                .username(userName)
+                .password(password)
+                .url(uri)
+                .build();
+    }
+
+    @Bean
+    public DataSource lazyRoutingDataSource(@Qualifier("routingDataSource") DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(@Qualifier("lazyRoutingDataSource") DataSource dataSource) {
+        EntityManagerFactoryBuilder entityManagerFactoryBuilder = createEntityManagerFactoryBuilder(jpaProperties);
+        return entityManagerFactoryBuilder.dataSource(dataSource)
+                .packages("com.imhero")
+                .build();
+    }
+
+    private EntityManagerFactoryBuilder createEntityManagerFactoryBuilder(JpaProperties jpaProperties) {
+        return new EntityManagerFactoryBuilder(new HibernateJpaVendorAdapter(), jpaProperties.getProperties(), null);
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+        JpaTransactionManager transactionManager = new JpaTransactionManager();
+        transactionManager.setEntityManagerFactory(entityManagerFactory);
+        return transactionManager;
+    }
+}

--- a/src/main/java/com/imhero/config/datasource/ReplicationRoutingSource.java
+++ b/src/main/java/com/imhero/config/datasource/ReplicationRoutingSource.java
@@ -1,0 +1,57 @@
+package com.imhero.config.datasource;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Profile("local")
+@Slf4j
+public class ReplicationRoutingSource extends AbstractRoutingDataSource {
+    @Getter
+    private SlaveNames<String> slaveNames;
+
+    @Override
+    public void setTargetDataSources(Map<Object, Object> targetDataSources) {
+        super.setTargetDataSources(targetDataSources);
+
+        List<String> slaveNames = targetDataSources.keySet()
+                .stream()
+                .map(Object::toString)
+                .filter(str -> str.contains(DataSourceType.SLAVE.getName()))
+                .collect(Collectors.toList());
+        this.slaveNames = new SlaveNames<>(slaveNames);
+    }
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+
+        if (isReadOnly) {
+            String nextSlaveName = slaveNames.getNext();
+            return nextSlaveName;
+        }
+        return DataSourceType.MASTER.getName();
+    }
+
+    private static class SlaveNames<T> {
+        private final List<T> values;
+        private int index = 0;
+
+        private SlaveNames(List<T> values) {
+            this.values = values;
+        }
+
+        public T getNext() {
+            if (index >= values.size() - 1) {
+                index = -1;
+            }
+            return values.get(++index);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,17 +10,26 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/imhero
 #    url: jdbc:mysql://mysql:3306/imhero  # for docker run
-    username: tkang
+    username: imhero
     password: 12345678
     driver-class-name: com.mysql.cj.jdbc.Driver
+    slaves:
+      slave1:
+        name: slave1
+        url: jdbc:mysql://localhost:3307/imhero
+        username: imhero
+        password: 12345678
+        driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     open-in-view: false
     defer-datasource-initialization: true
     hibernate.ddl-auto: validate
     properties:
-      hibernate.format_sql: true
-      hibernate.show_sql: true
-      hibernate.default_batch_fetch_size: 100
+      hibernate:
+        format_sql: true
+        show_sql: true
+        physical_naming_strategy: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
+        default_batch_fetch_size: 100
   session:
     store-type: redis
   redis:

--- a/src/test/groovy/com/imhero/ImheroApplicationTest.groovy
+++ b/src/test/groovy/com/imhero/ImheroApplicationTest.groovy
@@ -1,10 +1,12 @@
 package com.imhero
 
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import spock.lang.Specification
 
 import javax.transaction.Transactional
 
+@ActiveProfiles(profiles = "test")
 @Transactional
 @SpringBootTest
 class ImheroApplicationTest extends Specification{

--- a/src/test/groovy/com/imhero/config/datasource/ReplicationRoutingSourceTest.groovy
+++ b/src/test/groovy/com/imhero/config/datasource/ReplicationRoutingSourceTest.groovy
@@ -1,0 +1,57 @@
+package com.imhero.config.datasource
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import spock.lang.Specification
+
+@ActiveProfiles(profiles = "test")
+@SpringBootTest
+class ReplicationRoutingSourceTest extends Specification {
+
+    def "master data source"() {
+        setup:
+        def targetDataSources = [
+                slave1: "slaveDataSource1",
+                slave2: "slaveDataSource2",
+                master: "masterDataSource"
+        ]
+
+        def routingSource = new ReplicationRoutingSource()
+        routingSource.setTargetDataSources(targetDataSources)
+
+        when:
+        TransactionSynchronizationManager.setActualTransactionActive(true)
+        TransactionSynchronizationManager.setCurrentTransactionReadOnly(false)
+        String currentLookupKey = routingSource.determineCurrentLookupKey().toString()
+
+        then:
+        currentLookupKey.startsWith(DataSourceType.MASTER.getName())
+
+        cleanup:
+        TransactionSynchronizationManager.clear()
+    }
+
+    def "slave data source"() {
+        setup:
+        def targetDataSources = [
+                slave1: "slaveDataSource1",
+                slave2: "slaveDataSource2",
+                master: "masterDataSource"
+        ]
+
+        def routingSource = new ReplicationRoutingSource()
+        routingSource.setTargetDataSources(targetDataSources)
+
+        when:
+        TransactionSynchronizationManager.setActualTransactionActive(true)
+        TransactionSynchronizationManager.setCurrentTransactionReadOnly(true)
+        String currentLookupKey = routingSource.determineCurrentLookupKey().toString()
+
+        then:
+        currentLookupKey.startsWith(DataSourceType.SLAVE.getName())
+
+        cleanup:
+        TransactionSynchronizationManager.clear()
+    }
+}

--- a/src/test/groovy/com/imhero/reservation/repository/ReservationRepositoryTest.groovy
+++ b/src/test/groovy/com/imhero/reservation/repository/ReservationRepositoryTest.groovy
@@ -16,11 +16,13 @@ import com.imhero.user.domain.User
 import com.imhero.user.repository.UserRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 import java.time.LocalDateTime
 
+@ActiveProfiles(profiles = "test")
 @Transactional
 @SpringBootTest
 class ReservationRepositoryTest extends Specification {

--- a/src/test/groovy/com/imhero/reservation/service/ReservationServiceTest.groovy
+++ b/src/test/groovy/com/imhero/reservation/service/ReservationServiceTest.groovy
@@ -23,14 +23,15 @@ import com.imhero.user.components.AuthenticatedUser
 import com.imhero.user.domain.User
 import com.imhero.user.repository.UserRepository
 import com.imhero.user.service.UserService
-import org.redisson.api.RedissonClient
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 import java.time.LocalDateTime
 
+@ActiveProfiles(profiles = "test")
 @Transactional
 @SpringBootTest
 class ReservationServiceTest extends Specification {

--- a/src/test/groovy/com/imhero/show/repository/SeatRepositoryTest.groovy
+++ b/src/test/groovy/com/imhero/show/repository/SeatRepositoryTest.groovy
@@ -7,11 +7,13 @@ import com.imhero.show.domain.Seat
 import com.imhero.show.domain.ShowDetail
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 import javax.persistence.EntityManager
 
+@ActiveProfiles(profiles = "test")
 @SpringBootTest
 @Transactional
 class SeatRepositoryTest extends Specification {

--- a/src/test/groovy/com/imhero/show/repository/ShowDetailRepositoryTest.groovy
+++ b/src/test/groovy/com/imhero/show/repository/ShowDetailRepositoryTest.groovy
@@ -8,12 +8,14 @@ import com.imhero.user.domain.User
 import com.imhero.user.repository.UserRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 import javax.persistence.EntityManager
 import java.time.LocalDateTime
 
+@ActiveProfiles(profiles = "test")
 @SpringBootTest
 @Transactional
 class ShowDetailRepositoryTest extends Specification {

--- a/src/test/groovy/com/imhero/show/repository/ShowRepositoryTest.groovy
+++ b/src/test/groovy/com/imhero/show/repository/ShowRepositoryTest.groovy
@@ -10,12 +10,14 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 import javax.persistence.EntityManager
 import java.time.LocalDateTime
 
+@ActiveProfiles(profiles = "test")
 @Transactional
 @SpringBootTest
 class ShowRepositoryTest extends Specification {

--- a/src/test/groovy/com/imhero/show/service/SeatServiceTest.groovy
+++ b/src/test/groovy/com/imhero/show/service/SeatServiceTest.groovy
@@ -8,9 +8,11 @@ import com.imhero.show.domain.ShowDetail
 import com.imhero.show.dto.request.SeatRequest
 import com.imhero.show.repository.SeatRepository
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
+@ActiveProfiles(profiles = "test")
 @SpringBootTest
 @Transactional
 class SeatServiceTest extends Specification {

--- a/src/test/groovy/com/imhero/show/service/ShowDetailServiceTest.groovy
+++ b/src/test/groovy/com/imhero/show/service/ShowDetailServiceTest.groovy
@@ -8,12 +8,14 @@ import com.imhero.show.dto.request.ShowDetailRequest
 import com.imhero.show.repository.ShowDetailRepository
 import com.imhero.user.domain.User
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import spock.lang.Shared
 import spock.lang.Specification
 
 import java.time.LocalDateTime
 
+@ActiveProfiles(profiles = "test")
 @SpringBootTest
 @Transactional
 class ShowDetailServiceTest extends Specification {

--- a/src/test/groovy/com/imhero/show/service/ShowServiceTest.groovy
+++ b/src/test/groovy/com/imhero/show/service/ShowServiceTest.groovy
@@ -12,10 +12,12 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import spock.lang.Specification
 
+@ActiveProfiles(profiles = "test")
 @Transactional
 @SpringBootTest
 class ShowServiceTest extends Specification {

--- a/src/test/groovy/com/imhero/user/components/AuthenticatedUserTest.groovy
+++ b/src/test/groovy/com/imhero/user/components/AuthenticatedUserTest.groovy
@@ -14,9 +14,11 @@ import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
+@ActiveProfiles(profiles = "test")
 @SpringBootTest
 @Transactional
 class AuthenticatedUserTest extends Specification {

--- a/src/test/groovy/com/imhero/user/repository/UserRepositoryTest.groovy
+++ b/src/test/groovy/com/imhero/user/repository/UserRepositoryTest.groovy
@@ -4,12 +4,15 @@ import com.imhero.user.domain.Role
 import com.imhero.user.domain.User
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Profile
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 import javax.persistence.EntityManager
 
+@ActiveProfiles(profiles = "test")
 @Transactional
 @SpringBootTest
 class UserRepositoryTest extends Specification {

--- a/src/test/groovy/com/imhero/user/service/UserServiceTest.groovy
+++ b/src/test/groovy/com/imhero/user/service/UserServiceTest.groovy
@@ -13,12 +13,13 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import spock.lang.Shared
 
 import spock.lang.Specification
 
-
+@ActiveProfiles(profiles = "test")
 @Transactional
 @SpringBootTest
 class UserServiceTest extends Specification {

--- a/src/test/java/com/imhero/ImheroApplicationTests.java
+++ b/src/test/java/com/imhero/ImheroApplicationTests.java
@@ -2,9 +2,11 @@ package com.imhero;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import javax.transaction.Transactional;
 
+@ActiveProfiles(profiles = "test")
 @Transactional
 @SpringBootTest
 class ImheroApplicationTests {

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    activate:
+      on-profile: test
   datasource:
     url: jdbc:h2:mem:testdb
     username: sa


### PR DESCRIPTION
## 📌Linked Issues
- #37 

## ✏Change Details
- replication 설정을 추가하였습니다.
- 현재는 replica 서버가 1대이지만 복수로 늘어나도 할당 가능한 코드로 작성하였습니다.
- mysql dir 내부에 docker-compose 를 실행하면 자동으로 docker 로 mysql 서버 2대가 실행되게 하였습니다.
- 실행된 mysql 서버는 다른 작업 필요 없이 바로 사용 가능하도록 sh 파일을 작성하였습니다.
- 차후 main docker-compose 에 합칠 수 있도록 하겠습니다.
- db replication 은 현재는 local profile (default) 에서만 사용 가능합니다, 선택적으로 변경이 가능합니다.

## 💬Comment
- test 코드들에 replication 을 미적용하기 위해 'test' profile 을 적용하였습니다.
- replication test 는 [ReplicationRoutingSourceTest.groovy](https://github.com/f-lab-edu/IMHERO/compare/feature/%2337?expand=1#diff-e36a90a04a8f612f80ae014161ffb7f736fbf441bc506144005bc44cdf1a5782) 에서 확인하실 수 있습니다.

## 📑References
- <a href="https://velog.io/@max9106/DB-Spring-Replication">참고한 글</a>

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?